### PR TITLE
feat: implement bash helper with approval flow and execution continuation

### DIFF
--- a/llmvm/client/cli.py
+++ b/llmvm/client/cli.py
@@ -1506,7 +1506,7 @@ def url(
 
             async with httpx.AsyncClient(timeout=400.0) as client:
                 async with client.stream('POST', f'{llmvm_endpoint}/download', json=item.model_dump()) as response:
-                    objs = await stream_response(response, StreamPrinter().write)
+                    objs, _ = await stream_response(response, StreamPrinter().write)
             await response.aclose()
 
             session_thread = SessionThreadModel.model_validate(objs[-1])
@@ -1993,6 +1993,11 @@ def message(
 
     # Finalize the stream if inline markdown is enabled
     stream_printer.finalize_stream()
+
+    # Check if approval flow updated the thread
+    updated_thread = stream_printer.get_updated_thread()
+    if updated_thread:
+        thread = updated_thread
 
     if not thread.messages:
         rich.print(f'No messages were returned from either the LLMVM server, or the LLM model {model}.')

--- a/llmvm/client/client.py
+++ b/llmvm/client/client.py
@@ -414,7 +414,7 @@ class LLMVMClient():
                     f'{self.llmvm_endpoint}/v1/tools/compile',
                     json=thread_model.model_dump(),
                 ) as response:
-                    objs = await stream_response(response, stream_handler)
+                    objs, _ = await stream_response(response, stream_handler)
 
             await response.aclose()
 
@@ -529,7 +529,7 @@ class LLMVMClient():
                         except json.JSONDecodeError:
                             raise Exception(f"HTTP {response.status_code}: {error_content.decode('utf-8')}")
 
-                    objs = await stream_response(response, stream_handler)
+                    objs, _ = await stream_response(response, stream_handler)
 
             await response.aclose()
 

--- a/llmvm/config.yaml
+++ b/llmvm/config.yaml
@@ -58,6 +58,7 @@ helper_functions:
   # - llmvm.server.bcl.BCL.get_tvshow_ratings_and_details
   - llmvm.server.bcl.BCL.search_and_replace
   - llmvm.server.bcl.BCL.find
+  - llmvm.server.bcl.BCL.bash
   - llmvm.server.tools.browser.Browser
   - llmvm.server.tools.sheets.GoogleSheetsManager
   - llmvm.server.tools.macos_chrome_browser.MacOSChromeBrowser
@@ -86,3 +87,41 @@ client_role_color: 'bold bright_blue'
 client_repl_color: 'ansibrightblue'
 client_assistant_color: 'default'
 client_markdown_inline: true
+
+# bash helper configuration
+bash_helper:
+  default_approval_mode: 'on_request'  # never, on_request, on_failure, unless_trusted
+  default_sandbox_mode: 'workspace_write'  # read_only, workspace_write, danger_full_access
+  default_timeout: 10000  # milliseconds
+  session_approvals: true  # remember approvals for session
+  known_safe_commands:
+    - 'ls'
+    - 'cat'
+    - 'head'
+    - 'tail'
+    - 'grep'
+    - 'find'
+    - 'pwd'
+    - 'echo'
+    - 'which'
+    - 'whereis'
+    - 'date'
+    - 'whoami'
+    - 'id'
+    - 'uname'
+    - 'uptime'
+  dangerous_commands:
+    - 'rm'
+    - 'rmdir'
+    - 'mv'
+    - 'cp'
+    - 'dd'
+    - 'mkfs'
+    - 'fdisk'
+    - 'mount'
+    - 'umount'
+    - 'chmod'
+    - 'chown'
+    - 'su'
+    - 'sudo'
+    - 'passwd'

--- a/llmvm/server/bash_helper.py
+++ b/llmvm/server/bash_helper.py
@@ -31,6 +31,12 @@ class BashResult:
     was_sandboxed: bool = False
     was_approved: bool = True
 
+    def get_str(self) -> str:
+        """Return stdout and stderr (if present) for use with result()."""
+        if self.stderr:
+            return f"{self.stdout}\nSTDERR:\n{self.stderr}"
+        return self.stdout
+
 
 class CommandSafetyAssessor:
     """Assesses the safety of bash commands."""

--- a/llmvm/server/bash_helper.py
+++ b/llmvm/server/bash_helper.py
@@ -1,0 +1,336 @@
+#!/usr/bin/env python3
+"""
+Bash Helper for LLMVM - Provides safe bash command execution with approval and sandboxing.
+
+Inspired by query-muse's sophisticated sandbox and approval system.
+"""
+
+import os
+import shlex
+import subprocess
+import time
+import signal
+from dataclasses import dataclass
+from typing import Optional, List, Set
+import sys
+
+from llmvm.common.logging_helpers import setup_logging
+from llmvm.common.container import Container
+
+logging = setup_logging()
+
+
+@dataclass
+class BashResult:
+    """Result of executing a bash command."""
+    stdout: str
+    stderr: str
+    exit_code: int
+    command: str
+    execution_time: float
+    was_sandboxed: bool = False
+    was_approved: bool = True
+
+
+class CommandSafetyAssessor:
+    """Assesses the safety of bash commands."""
+
+    def __init__(self):
+        """Initialize with configuration."""
+        try:
+            container = Container(throw=False)
+            # Check if container was properly initialized
+            if hasattr(container, 'configuration'):
+                config = container.get('bash_helper', {})
+            else:
+                config = {}  # No config file available
+
+            # Load safe commands from config, with fallback defaults
+            self.known_safe_commands = set(config.get('known_safe_commands', [
+                'ls', 'cat', 'head', 'tail', 'grep', 'find', 'pwd', 'echo',
+                'which', 'whereis', 'date', 'whoami', 'id', 'uname', 'uptime'
+            ]))
+
+            # Load dangerous commands from config, with fallback defaults
+            self.dangerous_commands = set(config.get('dangerous_commands', [
+                'rm', 'rmdir', 'mv', 'cp', 'dd', 'mkfs', 'fdisk', 'mount',
+                'umount', 'chmod', 'chown', 'su', 'sudo', 'passwd'
+            ]))
+
+        except (ValueError, FileNotFoundError):
+            # Fallback to defaults if config is not available
+            self.known_safe_commands = {
+                'ls', 'cat', 'head', 'tail', 'grep', 'find', 'pwd', 'echo',
+                'which', 'whereis', 'date', 'whoami', 'id', 'uname', 'uptime'
+            }
+            self.dangerous_commands = {
+                'rm', 'rmdir', 'mv', 'cp', 'dd', 'mkfs', 'fdisk', 'mount',
+                'umount', 'chmod', 'chown', 'su', 'sudo', 'passwd'
+            }
+
+    def is_known_safe(self, command: str) -> bool:
+        """Check if a command is known to be safe for auto-approval."""
+        try:
+            # Parse the command to get the base command
+            tokens = shlex.split(command)
+            if not tokens:
+                return False
+
+            base_command = os.path.basename(tokens[0])
+            return base_command in self.known_safe_commands
+
+        except ValueError:
+            # Invalid shell syntax
+            return False
+
+    def needs_approval(self, command: str) -> bool:
+        """Check if a command needs explicit approval."""
+        try:
+            tokens = shlex.split(command)
+            if not tokens:
+                return True
+
+            base_command = os.path.basename(tokens[0])
+
+            # If it's a known safe command, no approval needed
+            if base_command in self.known_safe_commands:
+                return False
+
+            # If it's a known dangerous command, definitely needs approval
+            if base_command in self.dangerous_commands:
+                return True
+
+            # For unknown commands, err on the side of caution
+            return True
+
+        except ValueError:
+            # Invalid shell syntax, needs approval
+            return True
+
+
+class ApprovalSystem:
+    """Handles command approval requests."""
+
+    def __init__(self):
+        """Initialize with configuration."""
+        try:
+            container = Container(throw=False)
+            # Check if container was properly initialized
+            if hasattr(container, 'configuration'):
+                config = container.get('bash_helper', {})
+            else:
+                config = {}  # No config file available
+            self.session_approvals = config.get('session_approvals', True)
+        except (ValueError, FileNotFoundError):
+            self.session_approvals = True
+
+        self.approved_commands: Set[str] = set()  # Session-persistent approvals
+
+    def request_approval(self, command: str, cwd: str, justification: str = None) -> bool:
+        """Request approval for a command execution."""
+        # Check if already approved for this session (only if session approvals enabled)
+        if self.session_approvals and command in self.approved_commands:
+            logging.debug(f"Command '{command}' already approved for session")
+            return True
+
+        # For MVP, we'll implement a simple terminal prompt
+        # Later this can be extended to support web interface
+        return self._terminal_approval_prompt(command, cwd, justification)
+
+    def _terminal_approval_prompt(self, command: str, cwd: str, justification: str = None) -> bool:
+        """Show terminal prompt for command approval."""
+        # Check if we have an interactive terminal
+        import sys
+        if not sys.stdin.isatty() or not sys.stdout.isatty():
+            # Running in non-interactive mode (e.g., server mode)
+            # SECURITY: Never auto-approve commands in non-interactive mode
+            # This should be handled by proper client-server approval flow
+            logging.warning(f"Command approval required but no interactive terminal available: {command}")
+            logging.warning("Denying command execution for security. Implement proper approval flow.")
+            return False
+
+        print(f"\n🔐 Bash Command Approval Required")
+        print(f"Command: {command}")
+        print(f"Working Directory: {cwd}")
+        if justification:
+            print(f"Justification: {justification}")
+        print("\nOptions:")
+        print("  (a)pprove - Execute this command once")
+        print("  (s)ession - Execute and auto-approve for this session")
+        print("  (d)eny - Do not execute this command")
+
+        while True:
+            try:
+                response = input("Your choice [a/s/d]: ").lower().strip()
+                if response in ['a', 'approve']:
+                    return True
+                elif response in ['s', 'session']:
+                    if self.session_approvals:
+                        self.approved_commands.add(command)
+                    return True
+                elif response in ['d', 'deny']:
+                    return False
+                else:
+                    print("Please enter 'a', 's', or 'd'")
+            except (KeyboardInterrupt, EOFError):
+                print("\nOperation cancelled.")
+                return False
+
+
+def execute_bash_command(
+    command: str,
+    timeout: Optional[int] = None,
+    approval_mode: Optional[str] = None,
+    sandbox_mode: Optional[str] = None,
+    justification: str = None,
+    cwd: str = None,
+    approval_system: Optional[ApprovalSystem] = None
+) -> BashResult:
+    """
+    Execute a bash command with approval and sandboxing.
+
+    Args:
+        command: The bash command to execute
+        timeout: Timeout in milliseconds (uses config default if None)
+        approval_mode: "never", "on_request", "on_failure", "unless_trusted" (uses config default if None)
+        sandbox_mode: "read_only", "workspace_write", "danger_full_access" (uses config default if None)
+        justification: Reason for executing this command
+        cwd: Working directory (defaults to current)
+        approval_system: Approval system to use (for testing)
+
+    Returns:
+        BashResult with execution details
+    """
+    start_time = time.time()
+    cwd = cwd or os.getcwd()
+
+    # Load configuration defaults
+    try:
+        container = Container(throw=False)
+        # Check if container was properly initialized
+        if hasattr(container, 'configuration'):
+            config = container.get('bash_helper', {})
+        else:
+            config = {}  # No config file available
+
+        timeout = timeout if timeout is not None else config.get('default_timeout', 10000)
+        approval_mode = approval_mode if approval_mode is not None else config.get('default_approval_mode', 'on_request')
+        sandbox_mode = sandbox_mode if sandbox_mode is not None else config.get('default_sandbox_mode', 'workspace_write')
+
+    except (ValueError, FileNotFoundError):
+        # Fallback to defaults if config is not available
+        timeout = timeout if timeout is not None else 10000
+        approval_mode = approval_mode if approval_mode is not None else 'on_request'
+        sandbox_mode = sandbox_mode if sandbox_mode is not None else 'workspace_write'
+
+    # Initialize systems
+    if approval_system is None:
+        approval_system = ApprovalSystem()
+
+    safety_assessor = CommandSafetyAssessor()
+
+    # Safety assessment
+    needs_approval = False
+    if approval_mode == "never":
+        needs_approval = False
+    elif approval_mode == "unless_trusted":
+        needs_approval = not safety_assessor.is_known_safe(command)
+    elif approval_mode == "on_request":
+        needs_approval = safety_assessor.needs_approval(command)
+    elif approval_mode == "on_failure":
+        needs_approval = False  # Try first, ask for approval on failure
+
+    # Request approval if needed
+    if needs_approval:
+        approved = approval_system.request_approval(command, cwd, justification)
+        if not approved:
+            execution_time = time.time() - start_time
+            return BashResult(
+                stdout="",
+                stderr="Command denied by user",
+                exit_code=1,
+                command=command,
+                execution_time=execution_time,
+                was_approved=False
+            )
+
+    # Execute the command
+    try:
+        # For MVP, we'll use basic subprocess execution
+        # Later we can add sandboxing for macOS
+        result = subprocess.run(
+            command,
+            shell=True,
+            capture_output=True,
+            text=True,
+            timeout=timeout / 1000.0,  # Convert to seconds
+            cwd=cwd
+        )
+
+        execution_time = time.time() - start_time
+
+        return BashResult(
+            stdout=result.stdout,
+            stderr=result.stderr,
+            exit_code=result.returncode,
+            command=command,
+            execution_time=execution_time,
+            was_approved=True
+        )
+
+    except subprocess.TimeoutExpired:
+        execution_time = time.time() - start_time
+        return BashResult(
+            stdout="",
+            stderr=f"Command timed out after {timeout}ms",
+            exit_code=124,  # Standard timeout exit code
+            command=command,
+            execution_time=execution_time,
+            was_approved=True
+        )
+
+    except Exception as e:
+        execution_time = time.time() - start_time
+        return BashResult(
+            stdout="",
+            stderr=f"Execution error: {str(e)}",
+            exit_code=1,
+            command=command,
+            execution_time=execution_time,
+            was_approved=True
+        )
+
+
+def execute_bash_command_for_testing(
+    command: str,
+    timeout: Optional[int] = None,
+    approval_system=None,
+    cwd: str = None,
+    justification: str = None
+) -> BashResult:
+    """
+    Test-friendly version of bash command execution.
+    Used by unit tests with fake approval system.
+    """
+    # Special handling for test approval systems that have different interface
+    class TestApprovalSystemAdapter(ApprovalSystem):
+        def __init__(self, fake_approval_system):
+            super().__init__()
+            self.fake_system = fake_approval_system
+
+        def request_approval(self, command: str, cwd: str, justification: str = None) -> bool:
+            return self.fake_system.request_approval(command, cwd, justification)
+
+    # If we have a test approval system, adapt it
+    if approval_system and hasattr(approval_system, 'request_approval'):
+        approval_system = TestApprovalSystemAdapter(approval_system)
+
+    return execute_bash_command(
+        command=command,
+        timeout=timeout,
+        approval_mode="on_request",
+        sandbox_mode="workspace_write",
+        justification=justification,
+        cwd=cwd,
+        approval_system=approval_system
+    )

--- a/llmvm/server/execution_continuation.py
+++ b/llmvm/server/execution_continuation.py
@@ -1,0 +1,217 @@
+"""
+Execution continuation system for bash approval flow.
+
+When a bash command needs approval, we pause the execution and store the context.
+After approval, we resume execution with the BashResult replacing the ApprovalRequest.
+"""
+
+import uuid
+import asyncio
+import logging
+from typing import Dict, Optional, Any, Callable, Awaitable
+from dataclasses import dataclass
+
+from llmvm.common.objects import ApprovalRequest, AstNode
+from llmvm.server.bash_helper import BashResult
+
+logging = logging.getLogger(__name__)
+
+@dataclass
+class ExecutionContext:
+    """Complete stored execution context for continuation after approval"""
+    # Core execution data
+    approval_request: ApprovalRequest
+    execution_id: str
+    code_execution_result: list  # The original result list with ApprovalRequest
+    runtime_state: Any
+    messages: list
+
+    # Original request parameters needed for continuation
+    thread_id: int
+    temperature: float
+    model: str
+    max_output_tokens: Optional[int]
+    compression: Any  # TokenCompressionMethod
+    cookies: list[dict]
+    helpers: list  # list[Callable]
+    template_args: dict[str, Any]
+    thinking: bool
+
+    # Response handling
+    stream_handler: Callable[[AstNode], Awaitable[None]]
+    original_queue: Any  # The original response queue
+    original_controller: Any  # Reference to the original ExecutionController
+    continuation_callback: Optional[Callable] = None
+
+class ExecutionContinuationRegistry:
+    """Registry for paused executions waiting for bash approval"""
+
+    _instance: Optional['ExecutionContinuationRegistry'] = None
+
+    def __new__(cls):
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+            cls._instance._pending: Dict[str, ExecutionContext] = {}
+        return cls._instance
+
+    def pause_execution(self,
+                       approval_request: ApprovalRequest,
+                       code_execution_result: list,
+                       runtime_state: Any,
+                       messages: list,
+                       # Original request context
+                       thread_id: int,
+                       temperature: float,
+                       model: str,
+                       max_output_tokens: Optional[int],
+                       compression: Any,
+                       cookies: list[dict],
+                       helpers: list,
+                       template_args: dict[str, Any],
+                       thinking: bool,
+                       # Response handling
+                       stream_handler: Callable[[AstNode], Awaitable[None]],
+                       original_queue: Any,
+                       original_controller: Any) -> str:
+        """
+        Pause execution and store context for later resumption.
+
+        Returns:
+            execution_id: Unique ID to resume execution later
+        """
+        execution_id = str(uuid.uuid4())
+
+        # Add execution_id to approval request for client to send back
+        approval_request.execution_id = execution_id
+
+        context = ExecutionContext(
+            approval_request=approval_request,
+            execution_id=execution_id,
+            code_execution_result=code_execution_result.copy(),
+            runtime_state=runtime_state,
+            messages=messages.copy(),
+            # Original request context
+            thread_id=thread_id,
+            temperature=temperature,
+            model=model,
+            max_output_tokens=max_output_tokens,
+            compression=compression,
+            cookies=cookies.copy(),
+            helpers=helpers.copy(),
+            template_args=template_args.copy(),
+            thinking=thinking,
+            # Response handling
+            stream_handler=stream_handler,
+            original_queue=original_queue,
+            original_controller=original_controller
+        )
+
+        self._pending[execution_id] = context
+
+        logging.info(f"🔍 CONTINUATION: Paused execution {execution_id} for approval")
+        return execution_id
+
+
+    async def resume_execution(self, execution_id: str, bash_result: BashResult,
+                                        controller: Any, stream_handler: Any) -> tuple[bool, list]:
+        """
+        Resume paused execution within the current request context.
+
+        This method reuses the current controller and stream_handler instead of
+        creating a new execution context, allowing for proper streaming.
+        """
+        if execution_id not in self._pending:
+            logging.error(f"🔍 CONTINUATION: No pending execution found for {execution_id}")
+            return (False, [])
+
+        context = self._pending[execution_id]
+
+        # Replace ApprovalRequest with BashResult in the execution results
+        updated_results = []
+        replaced_count = 0
+        logging.info(f"🔍 CONTINUATION: Processing {len(context.code_execution_result)} execution results")
+
+        for i, item in enumerate(context.code_execution_result):
+            logging.info(f"🔍   Result {i}: {type(item).__name__}")
+
+            if isinstance(item, ApprovalRequest) and item.execution_id == execution_id:
+                # Replace ApprovalRequest with BashResult
+                updated_results.append(bash_result)
+                replaced_count += 1
+                logging.info(f"🔍   REPLACED ApprovalRequest with BashResult at position {i}")
+                logging.info(f"🔍   BashResult: stdout='{bash_result.stdout[:100]}...', exit_code={bash_result.exit_code}")
+            else:
+                updated_results.append(item)
+
+        logging.info(f"🔍 CONTINUATION: Replaced {replaced_count} ApprovalRequest(s) with BashResult")
+
+        # Build the continuation message with results
+        from llmvm.common.helpers import Helpers
+        from llmvm.common.objects import TextContent, User
+
+        # Build content messages with clear context about what happened
+        content_messages = [
+            TextContent("The bash command you requested has been completed. Here are the results:"),
+            TextContent("<helpers_result>")
+        ]
+
+        for c in updated_results:
+            from llmvm.common.objects import Content
+            if isinstance(c, Content):
+                content_messages.append(c)
+            else:
+                content_messages.append(TextContent(Helpers.str_get_str(c)))
+
+        content_messages.extend([
+            TextContent("</helpers_result>"),
+            TextContent("Please process these results and provide a complete response to the user's original request. Do not run the command again.")
+        ])
+
+        # Create User message with the results
+        completed_code_user_message = User(content_messages, hidden=False)
+
+        # Add the completed message to the message list
+        continuation_messages = context.messages.copy()
+        continuation_messages.append(completed_code_user_message)
+
+        logging.info(f"🔍 CONTINUATION: Built continuation with {len(continuation_messages)} messages")
+
+        # Clean up pending execution
+        del self._pending[execution_id]
+
+        # Continue execution using the provided controller and stream_handler
+        try:
+            logging.info(f"🔍 CONTINUATION: Continuing execution with provided controller")
+
+            # Convert messages to the format expected by aexecute_continuation
+            from llmvm.common.objects import MessageModel
+            converted_messages = [MessageModel.to_message(msg) if hasattr(msg, 'content') else msg
+                                for msg in continuation_messages]
+
+            result_messages, updated_runtime_state = await controller.aexecute_continuation(
+                messages=converted_messages,
+                temperature=context.temperature,
+                model=context.model,
+                max_output_tokens=context.max_output_tokens,
+                compression=context.compression,
+                stream_handler=stream_handler,  # Use the current request's stream handler
+                template_args=context.template_args,
+                helpers=context.helpers,
+                cookies=context.cookies,
+                runtime_state=context.runtime_state,
+                thinking=context.thinking
+            )
+
+            logging.info(f"🔍 CONTINUATION: Execution completed successfully with {len(result_messages)} result messages")
+            return (True, result_messages)
+
+        except Exception as e:
+            logging.error(f"🔍 CONTINUATION: Failed to continue execution: {e}")
+            import traceback
+            traceback.print_exc()
+            return (False, [])
+
+
+    def get_pending_count(self) -> int:
+        """Get number of pending executions"""
+        return len(self._pending)

--- a/llmvm/server/python_execution_controller.py
+++ b/llmvm/server/python_execution_controller.py
@@ -44,6 +44,7 @@ from llmvm.common.objects import (
 )
 from llmvm.common.openai_executor import OpenAIExecutor
 from llmvm.server.auto_global_dict import AutoGlobalDict
+from llmvm.server.bash_helper import BashResult
 
 logging = setup_logging()
 
@@ -882,6 +883,8 @@ class ExecutionController(Controller):
                 ]
             elif Helpers.is_function(result):
                 return [TextContent(Helpers.get_function_description_flat(result))]
+            elif isinstance(result, BashResult):
+                return [TextContent(result.get_str())]
             else:
                 logging.error(f"Unknown content type: {type(result)}, returning shape")
                 methods = f"The result is an instance of type {type(result)} with the following methods and static methods:\n"


### PR DESCRIPTION
- Add bash helper with approval system for command execution safety
- Implement execution continuation registry for pause/resume workflow
- Add unified approval flow using single /v1/tools/completions endpoint
- Preserve conversation context across approval interactions
- Support both session-based and per-command approval modes
- Add proper error handling and runtime state management

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
